### PR TITLE
Fix subsetting error for Legendre polynomials

### DIFF
--- a/R/FUN_stats.R
+++ b/R/FUN_stats.R
@@ -5,7 +5,7 @@ leg <- function(x,n=1,u=-1,v=1, intercept=TRUE, intercept1=FALSE){
                                                     x=orthopolynom::scaleX(x, u=u, v=v))))
   colnames(leg4) <- paste("leg",0:(ncol(leg4)-1),sep="")
   if(!intercept){
-    leg4 <- as.matrix(leg4[, 2:ncol(leg4)])
+    leg4 <- leg4[, 2:ncol(leg4), drop = FALSE]
   }
   if(intercept1){
     leg4 <- leg4*sqrt(2)


### PR DESCRIPTION
The default behavior of `leg` names the columns of the coefficient matrix (leg0, leg1, etc.), which are used to construct the design matrix in the call to `vs`. When the user requests a first order polynomial without the intercept term, the default behavior of the subset operator when a single column is requested from a matrix is to return a vector. Consequently, the column name is lost during the subset and not replaced after the call to `as.matrix`. Removing the call to `as.matrix` and adding the `drop = FALSE` argument to the subset operator preserves the matrix structure and the column name even when keeping a single column from the original coefficient matrix.